### PR TITLE
WIP: add search and sorting

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -21,6 +21,9 @@
 
             .yes { color: green; }
             .no { color: red; }
+
+            .sorting_asc:after { content: " ▲"; }
+            .sorting_desc:after { content: " ▼"; }
         </style>
     </head>
     <body>
@@ -34,7 +37,7 @@
             <label><input type="checkbox" id="auto_reload">Auto reload</label>
         </p>
 
-        <table>
+        <table id="data">
             <thead>
                 <tr>
                     <th>Number</th>
@@ -63,6 +66,9 @@
                 {% endfor %}
             </tbody>
         </table>
+
+        <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
+        <script src="//cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
 
         <script>
             document.getElementById('rollup').onclick = function(ev) {
@@ -100,6 +106,13 @@
             document.getElementById('auto_reload').checked = localStorage.homu_auto_reload == 'true';
 
             handle_auto_reload();
+
+            $(document).ready(function(){
+                $('#data').DataTable({
+                    paging: false,
+                    order: [],
+                });
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
This builds ontop of #31 to implement search and sorting of the data by including the DataTable library (and its jquery dependency). For now I'm pulling them in over their respective CDNs for simplicity, but we can of course download them and include them as part of homu. Your call.

UI untouched:
![screenshot from 2015-01-19 16 38 36](https://cloud.githubusercontent.com/assets/1136864/5808313/0ebdef28-9ffa-11e4-97c1-b03ea725828f.png)

Searching for collections-related PRs:
![screenshot from 2015-01-19 16 39 37](https://cloud.githubusercontent.com/assets/1136864/5808311/07d37c50-9ffa-11e4-998e-d8974ca30f50.png)

Sorting by assignee:
![screenshot from 2015-01-19 16 40 44](https://cloud.githubusercontent.com/assets/1136864/5808306/02273b98-9ffa-11e4-8f26-d6c3d190b998.png)

Searching for niko-related PRs, sorted by assignee:
![screenshot from 2015-01-19 16 40 55](https://cloud.githubusercontent.com/assets/1136864/5808305/0068123c-9ffa-11e4-8364-9c5480cbcdcf.png)

Fixes #10 #9 