### PR TITLE
enable updating of the rollup branch without creating a new PR

### DIFF
--- a/homu/html/queue.html
+++ b/homu/html/queue.html
@@ -33,7 +33,8 @@
         <h1>Homu queue - {{repo_label}}</h1>
 
         <p>
-            <button type="button" id="rollup">Create a rollup</button>
+            <button type="button" id="rollup">Create a rollup PR</button>
+            <button type="button" id="rollup_branch">Update the rollup Branch</button>
         </p>
 
         <p>

--- a/homu/server.py
+++ b/homu/server.py
@@ -70,8 +70,8 @@ def queue(repo_label):
         failed = len([x for x in pull_states if x.status == 'failure' or x.status == 'error']),
     )
 
-@get('/rollup')
-def rollup():
+@get('/rollup_branch')
+def rollup_branch():
     logger = g.logger.getChild('rollup')
 
     response.content_type = 'text/plain'
@@ -135,6 +135,14 @@ def rollup():
             failures.append(state.num)
         else:
             successes.append(state.num)
+
+    return successes, failures
+
+@get('/rollup')
+def rollup():
+    logger = g.logger.getChild('rollup')
+
+    successes, failures = rollup_branch()
 
     title = 'Rollup of {} pull requests'.format(len(successes))
     body = '- Successful merges: {}\n- Failed merges: {}'.format(


### PR DESCRIPTION
Sometimes I just want to update my rollup branch so I can locally test it and only create a PR if my rollup branch compiles locally. There's no need to bug the official repository with a PR.

Also this can be used to update an existing PR (not sure if that is useful).

WARNING: I have never programmed python before and I was not able to test this (I don't have a linux machine handy at this time). If someone could test this I would be very grateful, otherwise just review it and I'll test it within the next few days.
