### PR TITLE
Add a `linear_fake_merge` option (defaulting to True)

### DIFF
--- a/cfg.sample.toml
+++ b/cfg.sample.toml
@@ -44,6 +44,13 @@ try_users = []
 # Auto-squash commits. Requires the local Git command
 #autosquash = true
 
+# Whether homu should push a temporary merge commit that causes
+# github to think the PR was merged.  You need to disable this if
+# you have branch protection enabled.  Also, leaving this enabled
+# means that other people pulling master might transiently see
+# the merge commit.
+#linear_fake_merge = true
+
 ## branch names (these settings here are the defaults)
 #[repo.NAME.branch]
 #


### PR DESCRIPTION
One of my projects (projectatomic/rpm-ostree) has a protected master
branch.  I was rather horrified to realize that homu force-pushes to
master by default.  Admittedly, I understand this is the only way to
make github think the PR was merged (as opposed to just closed).

But in my mind, that's a deficiency of github - it should have an API
to allow us to "close merged with this commit".

Anyways, add an option so that those who prefer closing-as-unmerged over force
pushing can do that today.
