### PR TITLE
Now can run from checkout

### DIFF
--- a/homu/main.py
+++ b/homu/main.py
@@ -3,7 +3,7 @@ import github3
 import toml
 import json
 import re
-from . import utils
+from homu import utils
 import logging
 from threading import Thread, Lock
 import time
@@ -15,7 +15,7 @@ from itertools import chain
 from queue import Queue
 import os
 import subprocess
-from .git_helper import SSH_KEY_FILE
+from homu.git_helper import SSH_KEY_FILE
 import shlex
 import sys
 

--- a/homu/server.py
+++ b/homu/server.py
@@ -1,9 +1,9 @@
 import hmac
 import json
 import urllib.parse
-from .main import PullReqState, parse_commands, db_query, INTERRUPTED_BY_HOMU_RE, synchronize
-from . import utils
-from .utils import lazy_debug
+from homu.main import PullReqState, parse_commands, db_query, INTERRUPTED_BY_HOMU_RE, synchronize
+from homu import utils
+from homu.utils import lazy_debug
 import github3
 import jinja2
 import requests


### PR DESCRIPTION
Switched from relative imports to standard imports. This allows running from install as well as from the repository checkout:

```
$ python homu/main.py --help
usage: main.py [-h] [-v]

A bot that integrates with GitHub and your favorite continuous integration
service

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  Enable more verbose logging
$
```
